### PR TITLE
Features/lol/improve error responses

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,3 @@
+{
+  "extends": "eslint-config-probo"
+}

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -15,3 +15,7 @@ cacheMax: 500
 
 # Max age of proxy lookup responses in cache, in any unit (units default to ms). Defaults to 5 min
 cacheMaxAge: 1s
+
+redirectUrl: ''
+
+custom404Html: '<h1>404 - Build Not Found</h1><p>The build could not be found</p>'

--- a/index.js
+++ b/index.js
@@ -1,20 +1,22 @@
+'use strict';
+
 var config = require('./lib/config')
 var ms = require('ms')
 
 process.title = 'probo-proxy'
 
 config.load(function(error, config) {
-  if (error){
-    throw error
+  if (error) {
+    throw error;
   }
 
-  var server = require('./lib/proxy').server
-  var log = require('./lib/logger').getLogger()
+  var server = require('./lib/proxy').server;
+  var log = require('./lib/logger').getLogger();
 
   server.timeout = ms(config.serverTimeout || '10m');
 
-  server.listen(config.port, function(){
-    log.info("listening on port", server.address().port)
-    log.debug({config: config}, "config")
+  server.listen(config.port, function() {
+    log.info('listening on port', server.address().port);
+    log.debug({config: config}, 'config');
   });
 });

--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 'use strict';
 
-var config = require('./lib/config')
-var ms = require('ms')
+var config = require('./lib/config');
+var ms = require('ms');
 
-process.title = 'probo-proxy'
+process.title = 'probo-proxy';
 
 config.load(function(error, config) {
   if (error) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -2,6 +2,7 @@
 
 var path = require('path');
 var util = require('util');
+var _ = require('lodash');
 
 var Loader = require('yaml-config-loader');
 var yargs = require('yargs');
@@ -16,10 +17,16 @@ loader.on('error', function(error) {
 });
 
 var argv = yargs
-  .describe('port', 'The port to listen on.')
-  .alias('port', 'p')
-  .describe('config', 'A YAML config file or directory of yaml files to load, can be invoked multiple times and later files will override earlier.')
-  .alias('config', 'c')
+  .option('port', {
+    alias: 'p',
+    describe: 'The port to listen on.',
+    type: 'number',
+  })
+  .option('config', {
+    alias: 'c',
+    describe: 'A YAML config file or directory of yaml files to load, can be invoked multiple times and later files will override earlier.',
+    type: 'string',
+  })
   .argv;
 
 loader.add(path.resolve(path.join(__dirname, '..', 'defaults.yaml')));
@@ -29,15 +36,16 @@ if (argv.config) {
   if (typeof argv.config === 'string') {
     argv.config = [argv.config];
   }
-  for (var i in argv.config) {
-    loader.add(path.resolve(argv.config[i]));
-  }
+
+  argv.config.forEach(function(val) {
+    loader.add(path.resolve(val));
+  });
 }
 
 var setOptions = {};
 var key = null;
 for (key in yargs.argv) {
-  if (yargs.argv[key] !== undefined) {
+  if (!_.isUndefined(yargs.argv[key])) {
     setOptions[key] = yargs.argv[key];
   }
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -2,7 +2,6 @@
 
 var path = require('path');
 var util = require('util');
-var _ = require('lodash');
 
 var Loader = require('yaml-config-loader');
 var yargs = require('yargs');
@@ -45,7 +44,7 @@ if (argv.config) {
 var setOptions = {};
 var key = null;
 for (key in yargs.argv) {
-  if (!_.isUndefined(yargs.argv[key])) {
+  if (yargs.argv.hasOwnProperty(key)) {
     setOptions[key] = yargs.argv[key];
   }
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,13 +1,15 @@
-var path = require('path'),
-    util = require('util')
+'use strict';
+
+var path = require('path');
+var util = require('util');
 
 var Loader = require('yaml-config-loader');
 var yargs = require('yargs');
 var loader = new Loader();
 
-var log = require('./logger').getLogger("config")
+var log = require('./logger').getLogger('config');
 
-loader.on('error', function(error){
+loader.on('error', function(error) {
   if (error.name === 'YAMLException') {
     log.error({err: error}, util.print('Error parsing YAML file `', error.filePath, '`:', error.reason));
   }
@@ -25,7 +27,7 @@ loader.addAndNormalizeObject(process.env);
 
 if (argv.config) {
   if (typeof argv.config === 'string') {
-    argv.config = [ argv.config ];
+    argv.config = [argv.config];
   }
   for (var i in argv.config) {
     loader.add(path.resolve(argv.config[i]));
@@ -42,25 +44,27 @@ for (key in yargs.argv) {
 loader.addAndNormalizeObject(setOptions);
 
 
-var loaded_config = null
-function load(cb){
-  if(loaded_config){
-    log.debug("returning pre-loaded config")
+var loadedConfig = null;
+function load(cb) {
+  if (loadedConfig) {
+    log.debug('returning pre-loaded config');
 
-    if(typeof cb === 'function'){
-      cb(null, loaded_config)
+    if (typeof cb === 'function') {
+      cb(null, loadedConfig);
     }
-    return loaded_config
+    return loadedConfig;
   }
 
   loader.load(function(error, config) {
-    if (error) return cb && cb(error)
+    if (error) {
+      return cb && cb(error);
+    }
 
-    loaded_config = config
-    if(typeof cb === 'function'){
-      cb(null, loaded_config)
+    loadedConfig = config;
+    if (typeof cb === 'function') {
+      cb(null, loadedConfig);
     }
   });
 }
 
-module.exports = {load}
+module.exports = {load};

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,26 +1,29 @@
-var bunyan, logger;
+'use strict';
+
+var bunyan;
+var logger;
 
 bunyan = require('bunyan');
 
 logger = bunyan.createLogger({
-  name: "proxy",
+  name: 'proxy',
   level: 'debug',
   src: true,
   serializers: bunyan.stdSerializers,
   streams: [
     {
-      stream: process.stdout
-    }
-  ]
+      stream: process.stdout,
+    },
+  ],
 });
 
 module.exports = {
   getLogger: function(component) {
-    if(component) {
-      return logger.child({component: component})
+    if (component) {
+      return logger.child({component: component});
     }
     else {
       return logger;
     }
-  }
+  },
 };

--- a/lib/proxy-lookup.js
+++ b/lib/proxy-lookup.js
@@ -66,7 +66,7 @@ function lookup(dest, opts, cb) {
   var log = (opts.log || logger.getLogger()).child({component: 'proxy-lookup'});
   var config = configLoader.load();
 
-  // check cache first
+  // Check cache first...
   if (config.cacheEnabled) {
     var cached = cache.get(dest.dest);
     if (cached) {
@@ -79,15 +79,15 @@ function lookup(dest, opts, cb) {
   }
 
 
-  /* not cached, perform lookup */
+  // Proxy to the build is not cached, so we perform a lookup.
 
   // pull out .pr or .branch with .project, or .build. Adding .dest for good measure too
   // TODO: should we just use the dest object directly?
   var query = _.pick(dest, 'pr', 'branch', 'project', 'build', 'dest');
 
-  // example requests:
-  //  POST /container/proxy?project=123e4567-e89b-12d3-a456-426655440000&pr=2
-  //  POST /container/proxy?build=ccb2f22d-6b31-49e3-b95b-98ec823bd6f8
+  // Example requests:
+  //   POST /container/proxy?project=123e4567-e89b-12d3-a456-426655440000&pr=2
+  //   POST /container/proxy?build=ccb2f22d-6b31-49e3-b95b-98ec823bd6f8
   var path = config.containerLookupPath || '/container/proxy';
   var requestOpts = {
     qs: query,

--- a/lib/proxy-lookup.js
+++ b/lib/proxy-lookup.js
@@ -68,11 +68,11 @@ function lookup(dest, opts, cb) {
 
   // Check cache first...
   if (config.cacheEnabled) {
-    var cached = cache.get(dest.dest);
-    if (cached) {
+    var cachedProxyResponse = cache.get(dest.dest);
+    if (cachedProxyResponse) {
       log.debug('proxy lookup cache HIT: ' + dest.dest);
 
-      return cb(null, cached);
+      return cb(null, cachedProxyResponse);
     }
 
     log.debug('proxy lookup cache MISS: ' + dest.dest);
@@ -83,7 +83,7 @@ function lookup(dest, opts, cb) {
 
   // pull out .pr or .branch with .project, or .build. Adding .dest for good measure too
   // TODO: should we just use the dest object directly?
-  var query = _.pick(dest, 'pr', 'branch', 'project', 'build', 'dest');
+  var query = _.pick(dest, ['pr', 'branch', 'project', 'build', 'dest']);
 
   // Example requests:
   //   POST /container/proxy?project=123e4567-e89b-12d3-a456-426655440000&pr=2

--- a/lib/proxy-lookup.js
+++ b/lib/proxy-lookup.js
@@ -1,33 +1,35 @@
-var request = require('request')
-var LRU = require("lru-cache")
-var ms = require('ms')
-var _ = require('lodash')
-var util = require('util')
+'use strict';
 
-var logger = require('./logger')
-var configLoader = require('./config')
+var request = require('request');
+var LRU = require('lru-cache');
+var ms = require('ms');
+var _ = require('lodash');
+var util = require('util');
+
+var logger = require('./logger');
+var configLoader = require('./config');
 
 var cache;
 
-// init simple in memory cache of proxy responses
-configLoader.load(function(err, config){
-  if(err) throw err
-
-  function truthy(val){
-    return ["true", "t", "yes", "y", "1"].indexOf((""+val).toLowerCase()) >=0
+// Init simple in memory cache of proxy responses.
+configLoader.load(function(err, config) {
+  if (err) {
+    throw err;
   }
 
-  // console.log("cache enabled pre truthy:", util.inspect(config.cacheEnabled))
-  config.cacheEnabled = truthy(config.cacheEnabled)
-  // console.log("cache enabled post truthy:", util.inspect(config.cacheEnabled))
+  function truthy(val) {
+    return ['true', 't', 'yes', 'y', '1'].indexOf(('' + val).toLowerCase()) >= 0;
+  }
 
-  if(config.cacheEnabled){
+  config.cacheEnabled = truthy(config.cacheEnabled);
+
+  if (config.cacheEnabled) {
     cache = LRU({
       max: config.cacheMax || 500,
-      maxAge: ms(config.cacheMaxAge || "5m")
-    })
+      maxAge: ms(config.cacheMaxAge || '5m'),
+    });
   }
-})
+});
 
 
 
@@ -55,25 +57,25 @@ configLoader.load(function(err, config){
  *           }
  *         }
  */
-function lookup(dest, opts, cb){
-  if(typeof opts === 'function'){
-    cb = opts
-    opts = {}
+function lookup(dest, opts, cb) {
+  if (typeof opts === 'function') {
+    cb = opts;
+    opts = {};
   }
 
-  var log = (opts.log || logger.getLogger()).child({component: 'proxy-lookup'})
-  var config = configLoader.load()
+  var log = (opts.log || logger.getLogger()).child({component: 'proxy-lookup'});
+  var config = configLoader.load();
 
   // check cache first
-  if(config.cacheEnabled){
-    var cached = cache.get(dest.dest)
-    if(cached){
-      log.debug("proxy lookup cache HIT: " + dest.dest)
+  if (config.cacheEnabled) {
+    var cached = cache.get(dest.dest);
+    if (cached) {
+      log.debug('proxy lookup cache HIT: ' + dest.dest);
 
-      return cb(null, cached)
+      return cb(null, cached);
     }
 
-    log.debug("proxy lookup cache MISS: " + dest.dest)
+    log.debug('proxy lookup cache MISS: ' + dest.dest);
   }
 
 
@@ -81,43 +83,45 @@ function lookup(dest, opts, cb){
 
   // pull out .pr or .branch with .project, or .build. Adding .dest for good measure too
   // TODO: should we just use the dest object directly?
-  var query = _.pick(dest, "pr", "branch", "project", "build", "dest")
+  var query = _.pick(dest, 'pr', 'branch', 'project', 'build', 'dest');
 
   // example requests:
   //  POST /container/proxy?project=123e4567-e89b-12d3-a456-426655440000&pr=2
   //  POST /container/proxy?build=ccb2f22d-6b31-49e3-b95b-98ec823bd6f8
-  var path = config.containerLookupPath || "/container/proxy"
-  var request_opts = {
-    qs: query
-  }
-  if(config.containerLookupAuthToken){
-    request_opts.auth = {bearer: config.containerLookupAuthToken}
-  }
-  var url = config.containerLookupHost + path
+  var path = config.containerLookupPath || '/container/proxy';
+  var requestOpts = {
+    qs: query,
+  };
 
-  request.post(url, request_opts, function(err, response, body){
-    if(err) {
-      return cb(new Error("Proxy lookup failed: " + err.message))
+  if (config.containerLookupAuthToken) {
+    requestOpts.auth = {bearer: config.containerLookupAuthToken};
+  }
+  var url = config.containerLookupHost + path;
+
+  request.post(url, requestOpts, function(err, response, body) {
+    if (err) {
+      return cb(new Error('Proxy lookup failed: ' + err.message));
     }
 
     // TODO: should we cache error responses as well?
-    if(response.statusCode != 200){
-      return cb(new Error(body))
+    if (response.statusCode !== 200) {
+      return cb(new Error(body));
     }
 
     try {
-      body = JSON.parse(body)
-    } catch(e){
-      return cb(new Error("Invalid JSON in proxy lookup: " + util.inspect(body)))
+      body = JSON.parse(body);
+    }
+    catch (e) {
+      return cb(new Error('Invalid JSON in proxy lookup: ' + util.inspect(body)));
     }
 
-    log.debug({body: body, dest: dest}, "proxy response for " + dest.dest)
+    log.debug({body: body, dest: dest}, 'proxy response for ' + dest.dest);
 
-    if(config.cacheEnabled){
-      cache.set(dest.dest, body)
+    if (config.cacheEnabled) {
+      cache.set(dest.dest, body);
     }
-    cb(null, body)
-  })
+    cb(null, body);
+  });
 }
 
-module.exports = lookup
+module.exports = lookup;

--- a/lib/proxy-lookup.js
+++ b/lib/proxy-lookup.js
@@ -103,9 +103,13 @@ function lookup(dest, opts, cb) {
       return cb(new Error('Proxy lookup failed: ' + err.message));
     }
 
-    // TODO: should we cache error responses as well?
     if (response.statusCode !== 200) {
-      return cb(new Error(body));
+      var errorOptions = {
+        redirectUrl: config.redirectUrl,
+        custom404Html: config.custom404Html,
+      };
+      handleNonSuccessResponse(err, response, errorOptions, cb);
+      return;
     }
 
     try {
@@ -122,6 +126,31 @@ function lookup(dest, opts, cb) {
     }
     cb(null, body);
   });
+}
+
+function handleNonSuccessResponse(err, response, errorOptions, cb) {
+  var proxyError = new Error(response.body);
+  var proxyResponse = response.body;
+
+  try {
+    proxyResponse = JSON.parse(response.body);
+  }
+  catch (e) {
+    return cb(proxyError);
+  }
+
+  if (proxyResponse.errorCode) {
+    var proxyRedirect = errorOptions.redirectUrl ? errorOptions.redirectUrl + `?errorCode=${proxyResponse.errorCode}` : null;
+    var proxyHtml = errorOptions.custom404Html + `<p>${proxyResponse.message}</p>`;
+    proxyError = new Error();
+    proxyError.message = proxyResponse.message;
+    proxyError.statusCode = response.statusCode;
+    proxyError.errorCode = proxyResponse.errorCode;
+    proxyError.htmlResponse = proxyHtml;
+    proxyError.redirectUrl = proxyRedirect;
+  }
+
+  return cb(proxyError);
 }
 
 module.exports = lookup;

--- a/lib/proxy-rewrite.js
+++ b/lib/proxy-rewrite.js
@@ -1,28 +1,25 @@
-var util = require('util')
-
+'use strict';
 
 function rewrite(proxyReq, req, res, options) {
-  //proxyReq.setHeader('X-Special-Proxy-Header', 'foobar');
-  // console.log(util.inspect(options, null, 5))
-  // console.log("req headers:", proxyReq._headers)
-
-  // get the build config sites definitions
-  var sites, dest
+  // Get the build config sites definitions.
+  var sites;
+  var dest;
   try {
-    sites = options.probo.target.buildConfig.sites
-    dest = options.probo.target.dest
-  } catch (e) {
+    sites = options.probo.target.buildConfig.sites;
+    dest = options.probo.target.dest;
+  }
+  catch (e) {
     // ignore if we can't get to either
   }
 
-  if(sites && dest){
-    var site = dest.site || "default"
-    var host = sites[site]
+  if (sites && dest) {
+    var site = dest.site || 'default';
+    var host = sites[site];
 
-    if(host){
-      proxyReq.setHeader("host", host)
+    if (host) {
+      proxyReq.setHeader('host', host);
     }
   }
 }
 
-module.exports = rewrite
+module.exports = rewrite;

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -1,11 +1,12 @@
-var url = require('url')
-var http = require('http')
-var httpProxy = require('http-proxy')
-var uuid = require('uuid')
+'use strict';
 
-var utils = require('./utils')
-var proxy_lookup = require('./proxy-lookup')
-var proxy_rewrite = require('./proxy-rewrite')
+var http = require('http');
+var httpProxy = require('http-proxy');
+var uuid = require('uuid');
+
+var utils = require('./utils');
+var proxyLookup = require('./proxy-lookup');
+var proxyRewrite = require('./proxy-rewrite');
 
 var log = require('./logger').getLogger();
 
@@ -22,72 +23,73 @@ var proxy = httpProxy.createProxyServer({});
 // you need to modify the proxy request before the proxy connection
 // is made to the target.
 //
-proxy.on('proxyReq', proxy_rewrite);
+proxy.on('proxyReq', proxyRewrite);
 
 //
 // Listen for the `proxyRes` event on `proxy`.
 //
-proxy.on('proxyRes', function (proxyRes, req, res) {
-  //console.log('RAW Response from the target', JSON.stringify(proxyRes.headers, true, 2));
-  req.log.info({status: proxyRes.statusCode}, "proxy response")
+proxy.on('proxyRes', function(proxyRes, req, res) {
+  req.log.info({status: proxyRes.statusCode}, 'proxy response');
 
-  // set a header with the ID of the initial request
-  res.setHeader('X-Proxy-Request-Id', req.id)
+  // Set a header with the ID of the initial request.
+  res.setHeader('X-Proxy-Request-Id', req.id);
 });
 
 
-function respondWithLookupError(req, res, err){
-  req.log.error({err}, "Error looking up proxy information")
-  res.writeHead(400)
-  res.end(`Proxy error: ${err.message}\n`)
+function respondWithLookupError(req, res, err) {
+  req.log.error({err}, 'Error looking up proxy information');
+  res.writeHead(400);
+  res.end(`Proxy error: ${err.message}\n`);
 }
 
-function respondWithProxyError(req, res, err){
-  req.log.error({err}, "Error proxying request to container")
-  res.writeHead(500)
-  res.end(`Proxy error: ${err.message}\n`)
+function respondWithProxyError(req, res, err) {
+  req.log.error({err}, 'Error proxying request to container');
+  res.writeHead(500);
+  res.end(`Proxy error: ${err.message}\n`);
 }
 
 
 
 var server = http.createServer(function(req, res) {
-  req.id = uuid()
-  req.log = log.child({req_id: req.id}, true)
+  var dest;
+  req.id = uuid();
+  req.log = log.child({req_id: req.id}, true);
 
   try {
-    var dest = utils.getAndParseDest(req)
-    req.log.info({dest: dest}, "using dest:")
-  } catch (e){
-    return respondWithLookupError(req, res, e)
+    dest = utils.getAndParseDest(req);
+    req.log.info({dest: dest}, 'using dest:');
+  }
+  catch (e) {
+    return respondWithLookupError(req, res, e);
   }
 
-  proxy_lookup(dest, {log: req.log}, function(err, result){
-    if(err) return respondWithLookupError(req, res, err)
+  proxyLookup(dest, {log: req.log}, function(err, result) {
+    if (err) return respondWithLookupError(req, res, err);
 
     var target = {
       url: result.proxy.url,
       dest: dest,
-      buildConfig: result.buildConfig
-    }
+      buildConfig: result.buildConfig,
+    };
 
-    _proxy(target, function(err, request, response, target_obj){
+    _proxy(target, function(err, request, response, targetObj) {
       // callback only fires on error
       // return custom error
-      return respondWithProxyError(req, res, err)
-    })
-  })
+      return respondWithProxyError(req, res, err);
+    });
+  });
 
 
-  function _proxy(target, cb){
+  function _proxy(target, cb) {
     proxy.web(req, res, {
       target: target.url,
       xfwd: true,
       autoRewrite: true,
       probo: {
-        target: target
-      }
+        target: target,
+      },
     }, cb);
   }
 });
 
-module.exports = {server, proxy}
+module.exports = {server, proxy};

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -64,7 +64,9 @@ var server = http.createServer(function(req, res) {
   }
 
   proxyLookup(dest, {log: req.log}, function(err, result) {
-    if (err) return respondWithLookupError(req, res, err);
+    if (err) {
+      return respondWithLookupError(req, res, err);
+    }
 
     var target = {
       url: result.proxy.url,

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -3,6 +3,7 @@
 var http = require('http');
 var httpProxy = require('http-proxy');
 var uuid = require('uuid');
+var _ = require('lodash');
 
 var utils = require('./utils');
 var proxyLookup = require('./proxy-lookup');
@@ -38,6 +39,10 @@ proxy.on('proxyRes', function(proxyRes, req, res) {
 
 function respondWithLookupError(req, res, err) {
   req.log.error({err}, 'Error looking up proxy information');
+  if (err.errorCode) {
+    respondWith404Message(req, res, err);
+  }
+
   res.writeHead(400);
   res.end(`Proxy error: ${err.message}\n`);
 }
@@ -48,7 +53,40 @@ function respondWithProxyError(req, res, err) {
   res.end(`Proxy error: ${err.message}\n`);
 }
 
+function respondWith404Message(req, res, err) {
+  // If the request was from a browser asking for HTML, then hand back a
+  // redirect to another page.
+  function accepts(s) {
+    return req.headers.accept && req.headers.accept.indexOf(s) >= 0;
+  }
+  var htmlAcceptStrings = ['text/html', 'application/xhtml', 'application/xml'];
+  var jsonAcceptStrings = ['application/json'];
 
+  if (_.includes(_.map(htmlAcceptStrings, accepts), true)) {
+    if (err.redirectUrl) {
+      res.writeHead(302, {
+        location: err.redirectUrl,
+      });
+    }
+    else {
+      res.writeHead(404, {
+        'Content-Type': 'text/html',
+      });
+      res.write(err.htmlResponse);
+    }
+  }
+  else if (_.includes(_.map(jsonAcceptStrings, accepts), true)) {
+    res.writeHead(404, {
+      'Content-Type': 'application/json',
+    });
+    res.write(JSON.stringify(err));
+  }
+  else {
+    res.writeHead(404);
+    res.write(`Proxy error: ${err.message}\n`);
+  }
+  res.end();
+}
 
 var server = http.createServer(function(req, res) {
   var dest;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,30 +1,32 @@
-var url = require('url')
+'use strict';
 
-var parse_error_prefix = "Destination identifier parse error: "
+var url = require('url');
+
+var parseErrorPrefix = 'Destination identifier parse error: ';
 
 /**
  * destination identifier can be specified either via a subdomain or by
  * a proboDest/proboBuildId request param
  */
-function getDest(req){
+function getDest(req) {
   // check query first
-  var query = url.parse(req.url, true).query
-  if(query.proboDest || query.proboBuildId){
-    return query.proboDest || query.proboBuildId
+  var query = url.parse(req.url, true).query;
+  if (query.proboDest || query.proboBuildId) {
+    return query.proboDest || query.proboBuildId;
   }
 
-  // check hostname
-  var hostname = req.headers.host.split(':')[0] // includes port
-  var parts = hostname.split('.')
+  // Check the hostname. The hostname includes the port.
+  var hostname = req.headers.host.split(':')[0];
+  var parts = hostname.split('.');
 
-  if(parts.length < 3){
-    throw new Error(`Destination identifier not found in domain or query param, host: ${req.headers.host}, url: ${req.url}`)
+  if (parts.length < 3) {
+    throw new Error(`Destination identifier not found in domain or query param, host: ${req.headers.host}, url: ${req.url}`);
   }
 
   // parse out buildid[.host.com] part
-  var dest = parts[0]
+  var dest = parts[0];
 
-  return dest
+  return dest;
 }
 
 /**
@@ -57,86 +59,87 @@ function getDest(req){
  *   "github-proboci-probo-proxy--pr-23"                         --  project alias with pull request number
  *
  */
-function parseDest(dest){
-  var modifiers = dest.split('--')
+function parseDest(dest) {
+  var modifiers = dest.split('--');
 
-  var identifier = modifiers[0]
+  var identifier = modifiers[0];
   var ret = {
-    dest: dest
-  }
+    dest: dest,
+  };
 
-  var i
-  for(i = 1; i < modifiers.length; i++){
-    var modifier = parseModifier(modifiers[i])
-    switch(modifier.type){
-    case 'pr':
-      setPr(ret, modifier)
-      ret.project = identifier
-      break
-    case 'br':
-      setBranch(ret, modifier)
-      ret.project = identifier
-      break
-    case 'site':
-      setSite(ret, modifier)
-      break
-    default:
-      throw new Error(parse_error_prefix + "invalid modifier type: " + modifier.type)
+  var i;
+  for (i = 1; i < modifiers.length; i++) {
+    var modifier = parseModifier(modifiers[i]);
+    switch (modifier.type) {
+      case 'pr':
+        setPr(ret, modifier);
+        ret.project = identifier;
+        break;
+      case 'br':
+        setBranch(ret, modifier);
+        ret.project = identifier;
+        break;
+      case 'site':
+        setSite(ret, modifier);
+        break;
+      default:
+        throw new Error(parseErrorPrefix + 'invalid modifier type: ' + modifier.type);
     }
   }
 
-  if(!ret.project){
-    ret.build = identifier
+  if (!ret.project) {
+    ret.build = identifier;
   }
 
-  return ret
+  return ret;
 
-  function parseModifier(modifier){
-    var parts = modifier.split('-')
+  function parseModifier(modifier) {
+    var parts = modifier.split('-');
 
-    if(!parts[1]){
-      throw new Error(parse_error_prefix + "invalid modifier: " + modifier)
+    if (!parts[1]) {
+      throw new Error(parseErrorPrefix + 'invalid modifier: ' + modifier);
     }
 
+    // Reassemble parts[1:] pieces into a string
     return {
       type: parts[0],
-      value: parts.slice(1).join('-'), // reassemble parts[1:] pieces into a string
-      modifier: modifier
-    }
+      value: parts.slice(1).join('-'),
+      modifier: modifier,
+    };
   }
 
-  function setBranch(dest, branch){
-    if(dest.pr){
-      throw new Error(parse_error_prefix + `branch specified (${branch.value}), but PR already set (${dest.pr})`)
+  function setBranch(dest, branch) {
+    if (dest.pr) {
+      throw new Error(parseErrorPrefix + `branch specified (${branch.value}), but PR already set (${dest.pr})`);
     }
 
-    dest.branch = branch.value
+    dest.branch = branch.value;
   }
 
-  function setPr(dest, pr){
-    if(dest.branch){
-      throw new Error(parse_error_prefix + `PR specified (${pr.value}), but branch already set (${dest.branch})`)
+  function setPr(dest, pr) {
+    if (dest.branch) {
+      throw new Error(parseErrorPrefix + `PR specified (${pr.value}), but branch already set (${dest.branch})`);
     }
 
-    dest.pr = pr.value
+    dest.pr = pr.value;
   }
 
-  function setSite(dest, site){
-    if(dest.site){
-      throw new Error(parse_error_prefix + `multiple site definitions not allowed: ${site.value}`)
+  function setSite(dest, site) {
+    if (dest.site) {
+      throw new Error(parseErrorPrefix + `multiple site definitions not allowed: ${site.value}`);
     }
 
-    dest.site = site.value
+    dest.site = site.value;
   }
 }
 
-function getAndParseDest(req){
-  return parseDest(getDest(req))
+function getAndParseDest(req) {
+  return parseDest(getDest(req));
 }
 
 
 module.exports = {
   getDest: getDest,
   parseDest: parseDest,
-  getAndParseDest: getAndParseDest
-}
+  getAndParseDest: getAndParseDest,
+};

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
   "devDependencies": {
     "bluebird": "^2.10.0",
     "co-mocha": "^1.1.2",
+    "eslint": "^2.10.2",
+    "eslint-config-probo": "^1.0.2",
     "istanbul": "^0.3.19",
     "mocha": "^2.3.2",
     "nock": "^2.10.0",

--- a/package.json
+++ b/package.json
@@ -16,11 +16,11 @@
   "dependencies": {
     "bunyan": "^1.4.0",
     "http-proxy": "^1.11.1",
-    "lodash": "^3.10.1",
+    "lodash": "^4.12.0",
     "lru-cache": "^2.6.5",
     "ms": "^0.7.1",
     "request": "^2.60.0",
-    "restify": "^3.0.3",
+    "restify": "^4.0.4",
     "uuid": "^2.0.1",
     "yaml-config-loader": "^2.0.1",
     "yargs": "^4.6.0 "

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "request": "^2.60.0",
     "restify": "^3.0.3",
     "uuid": "^2.0.1",
-    "yaml-config-loader": "^1.2.2",
-    "yargs": "^3.16.1"
+    "yaml-config-loader": "^2.0.1",
+    "yargs": "^4.6.0 "
   },
   "devDependencies": {
     "bluebird": "^2.10.0",

--- a/test/__nockout.js
+++ b/test/__nockout.js
@@ -1,69 +1,71 @@
+'use strict';
+
 // NOCK CONFIGUATION
-// var default_nock_mode = "RECORD"
-var default_nock_mode = "PLAY"
+var defaultNockMode = 'PLAY';
 
-var nock = require('nock')
+var nock = require('nock');
 // opts: {processor, not_required, mode}
-function init_nock(fixture, opts){
-  var fixture_file = "./test/fixtures/" + fixture
+function initNock(fixture, opts) {
+  var fixtureFile = './test/fixtures/' + fixture;
 
-  var nocked = {}
-  var required_nocks = []
+  var nocked = {};
+  var requiredNocks = [];
 
-  opts = opts || {}
-  opts.not_required = opts.not_required || []
+  opts = opts || {};
+  opts.not_required = opts.not_required || [];
 
-  var nock_mode = opts.mode || default_nock_mode
+  var nockMode = opts.mode || defaultNockMode;
 
-  var nocks
-  if(nock_mode === "PLAY"){
-    nocks = nock.load(fixture_file)
+  var nocks;
+  if (nockMode === 'PLAY') {
+    nocks = nock.load(fixtureFile);
 
-    if(opts.processor){
-      nocks = opts.processor(nocks)
+    if (opts.processor) {
+      nocks = opts.processor(nocks);
     }
 
-    nocks.forEach(function(n, i){
-      nocked['loaded_' + i] = n
-    })
+    nocks.forEach(function(n, i) {
+      nocked['loaded_' + i] = n;
+    });
 
     // allow some mocks to be not required
-    Object.keys(nocked).filter(function(name){
-      return opts.not_required.indexOf(name) < 0
-    }).forEach(function(name){
-      required_nocks.push(nocked[name])
-    })
+    Object.keys(nocked).filter(function(name) {
+      return opts.not_required.indexOf(name) < 0;
+    }).forEach(function(name) {
+      requiredNocks.push(nocked[name]);
+    });
   }
 
-  if(nock_mode === "RECORD"){
-    console.log("recording")
+  if (nockMode === 'RECORD') {
+    console.log('recording');
     nock.recorder.rec({
       output_objects: true,
-      dont_print: true
-    })
+      dont_print: true,
+    });
   }
 
   return {
     nocked: nocked,
     nocks: nocks,
-    required: required_nocks,
-    cleanup: function(){
-      if(nock_mode === "RECORD"){
+    required: requiredNocks,
+    cleanup: function() {
+      if (nockMode === 'RECORD') {
         var nockCallObjects = nock.recorder.play();
-        require('fs').writeFileSync(fixture_file, JSON.stringify(nockCallObjects, null, 2));
+        require('fs').writeFileSync(fixtureFile, JSON.stringify(nockCallObjects, null, 2));
       }
 
       // makesure all internal calls were made
       try {
-        for(var nock_name in required_nocks){
-          required_nocks[nock_name].done();
+        for (var nockName in requiredNocks) {
+          requiredNocks[nockName].done();
         }
-      } finally {
-        nock.cleanAll()
       }
-    }
-  }
+      finally {
+        nock.cleanAll();
+      }
+    },
+  };
 }
 
 
-module.exports = init_nock
+module.exports = initNock;

--- a/test/__nockout.js
+++ b/test/__nockout.js
@@ -56,9 +56,9 @@ function initNock(fixture, opts) {
 
       // makesure all internal calls were made
       try {
-        for (var nockName in requiredNocks) {
-          requiredNocks[nockName].done();
-        }
+        requiredNocks.forEach(function(n) {
+          n.done();
+        });
       }
       finally {
         nock.cleanAll();

--- a/test/__setup.js
+++ b/test/__setup.js
@@ -1,12 +1,18 @@
+'use strict';
+
 // This file is name __setup so that it gets loaded first
 // and performs initialization for tests
-require('co-mocha')
+require('co-mocha');
 
 // effectivley silence the logging
 delete process.env.GRAYLOG_HOST;
-var logger = (require ('../lib/logger')).getLogger();
+var logger = (require('../lib/logger')).getLogger();
 logger._level = Number.POSITIVE_INFINITY;
 
 // APP CONFIGURATION
-process.env.CONTAINER_LOOKUP_HOST = "http://localhost:3020" // this will be nocked out
-process.env.CACHE_ENABLED = false // disable caching
+
+// this will be nocked out
+process.env.CONTAINER_LOOKUP_HOST = 'http://localhost:3020';
+
+// disable caching
+process.env.CACHE_ENABLED = false;

--- a/test/fixtures/proxy_nocks.json
+++ b/test/fixtures/proxy_nocks.json
@@ -66,6 +66,86 @@
     }
   },
   {
+    "scope": "http://localhost:3020",
+    "method": "POST",
+    "path": "/container/proxy?build=aab2f22d-6b31-49e3-b95b-98ec823bd6f8&dest=aab2f22d-6b31-49e3-b95b-98ec823bd6f8",
+    "body": "",
+    "status": 404,
+    "response": {
+      "errorCode": "404R",
+      "message": "Build has been reaped"
+    },
+    "headers": {
+      "content-type": "application/json",
+      "date": "Wed, 09 Sep 2015 16:14:57 GMT",
+      "connection": "close"
+    }
+  },
+  {
+    "scope": "http://localhost:3020",
+    "method": "POST",
+    "path": "/container/proxy?build=acb2f22d-6b31-49e3-b95b-98ec823bd6f8&dest=acb2f22d-6b31-49e3-b95b-98ec823bd6f8",
+    "body": "",
+    "status": 404,
+    "response": {
+      "errorCode": "404R",
+      "message": "Build has been reaped"
+    },
+    "headers": {
+      "content-type": "application/json",
+      "date": "Wed, 09 Sep 2015 16:14:57 GMT",
+      "connection": "close"
+    }
+  },
+  {
+    "scope": "http://localhost:3020",
+    "method": "POST",
+    "path": "/container/proxy?build=adb2f22d-6b31-49e3-b95b-98ec823bd6f8&dest=adb2f22d-6b31-49e3-b95b-98ec823bd6f8",
+    "body": "",
+    "status": 404,
+    "response": {
+      "errorCode": "404R",
+      "message": "Build has been reaped"
+    },
+    "headers": {
+      "content-type": "application/json",
+      "date": "Wed, 09 Sep 2015 16:14:57 GMT",
+      "connection": "close"
+    }
+  },
+  {
+    "scope": "http://localhost:3020",
+    "method": "POST",
+    "path": "/container/proxy?build=eeb2f22d-6b31-49e3-b95b-98ec823bd6f8&dest=eeb2f22d-6b31-49e3-b95b-98ec823bd6f8",
+    "body": "",
+    "status": 404,
+    "response": {
+      "errorCode": "404R",
+      "message": "Build has been reaped"
+    },
+    "headers": {
+      "content-type": "application/json",
+      "date": "Wed, 09 Sep 2015 16:14:57 GMT",
+      "connection": "close"
+    }
+  },
+  {
+    "scope": "http://localhost:3020",
+    "method": "POST",
+    "path": "/container/proxy?build=efb2f22d-6b31-49e3-b95b-98ec823bd6f8&dest=efb2f22d-6b31-49e3-b95b-98ec823bd6f8",
+    "body": "",
+    "status": 404,
+    "response": {
+      "errorCode": "404R",
+      "message": "Build has been reaped"
+    },
+    "headers": {
+      "content-type": "application/json",
+      "date": "Wed, 09 Sep 2015 16:14:57 GMT",
+      "connection": "close"
+    }
+  },
+  {
     "scope": "http://localhost:49348/?proboBuildId=ccb2f22d-6b31-49e3-b95b-98ec823bd6f8",
     "method": "GET",
     "path": "/?proboBuildId=ccb2f22d-6b31-49e3-b95b-98ec823bd6f8",

--- a/test/server.js
+++ b/test/server.js
@@ -176,7 +176,7 @@ describe('lookup tests', function() {
           target: {
             url: 'http://localhost:49348/',
             dest: dest || {
-              id: 'ccb2f22d-6b31-49e3-b95b-98ec823bd6f8', post: undefined,
+              id: 'ccb2f22d-6b31-49e3-b95b-98ec823bd6f8', post: null,
             },
             buildConfig: {
               image: 'lepew/ubuntu-14.04-lamp',

--- a/test/server.js
+++ b/test/server.js
@@ -1,188 +1,174 @@
+'use strict';
+
 // APP LIBS BEING TESTED
-var config = require('../lib/config')
+var config = require('../lib/config');
 
 // HTTP HELPERS
-var http = require('http')
+var http = require('http');
 var request = require('superagent-promise')(require('superagent'), require('bluebird'));
 
-var nockout = require('./__nockout')
+var nockout = require('./__nockout');
 
-describe("lookup tests", function(){
-  var conf, server, proxy, proxy_lookup, proxy_rewrite
+describe('lookup tests', function() {
+  var conf;
+  var server;
+  var proxyLookup;
+  var proxyRewrite;
 
-  before("load config", function(done){
-    config.load(function(err, _config){
-      conf = _config
-      // console.log({conf: conf}, "config")
+  before('load config', function(done) {
+    config.load(function(err, _config) {
+      conf = _config;
 
       // make sure to require these after config is loaded
-      server = require('../lib/proxy').server
-      proxy = require('../lib/proxy').proxy
-      proxy_lookup = require('../lib/proxy-lookup')
-      proxy_rewrite = require('../lib/proxy-rewrite')
+      server = require('../lib/proxy').server;
+      proxyLookup = require('../lib/proxy-lookup');
+      proxyRewrite = require('../lib/proxy-rewrite');
 
-      done(err, conf)
-    })
-  })
-
-  before("start server", function(done){
-    server.listen(0, function(){
-      console.log("listening on port", server.address().port)
-      done()
+      done(err, conf);
     });
   });
 
-  after("stop server", function(){
-    server.close()
+  before('start server', function(done) {
+    server.listen(0, function() {
+      console.log('listening on port', server.address().port);
+      done();
+    });
   });
 
-  describe("proxy lookup", function(){
-    var nocker
+  after('stop server', function() {
+    server.close();
+  });
 
-    before("nock out network calls", function(){
-      nocker = nockout('proxy_lookup_nocks.json')
+  describe('proxy lookup', function() {
+    var nocker;
+
+    before('nock out network calls', function() {
+      nocker = nockout('proxy_lookup_nocks.json');
     });
 
-    after("cleanup", function(){
-      nocker.cleanup()
+    after('cleanup', function() {
+      nocker.cleanup();
     });
 
-    it("good build id", function(done){
-      var buildId = "ccb2f22d-6b31-49e3-b95b-98ec823bd6f8"
-      proxy_lookup({build: buildId}, function(err, response){
-        if(err) return done(err)
+    it('good build id', function(done) {
+      var buildId = 'ccb2f22d-6b31-49e3-b95b-98ec823bd6f8';
+      proxyLookup({build: buildId}, function(err, response) {
+        if (err) {
+          return done(err);
+        }
 
         response.should.containEql({
           proxy: {
             host: 'localhost',
             port: '49348',
-            url: 'http://localhost:49348/'
-          }
-        })
+            url: 'http://localhost:49348/',
+          },
+        });
 
-        response.should.have.properties(["buildConfig", "status"])
-        done()
-      })
-    })
+        response.should.have.properties(['buildConfig', 'status']);
+        done();
+      });
+    });
 
-    it("bad build id", function(done){
-      var buildId = "404"
-      proxy_lookup({build: buildId}, function(err, response){
+    it('bad build id', function(done) {
+      var buildId = '404';
+      proxyLookup({build: buildId}, function(err, response) {
         err.message.should.eql(
           '{"code":"ResourceNotFound","message":"Build not found for build id: 404"}'
-        )
-        done()
-      })
-    })
+        );
+        done();
+      });
+    });
 
 
-    it("good project & pr", function(done){
-      proxy_lookup({pr: "2", project: "project-alias"}, function(err, response){
-        if(err) return done(err)
-
-        // no need for the full proxy response here,
-        // just verify that we hit the right endpoint
-        response.should.eql({mocked: true, pr: '2', project: 'project-alias'})
-        done()
-      })
-    })
-
-    it("good project & branch", function(done){
-      proxy_lookup({branch: "branch", project: "project-alias"}, function(err, response){
-        if(err) return done(err)
-
-        // no need for the full proxy response here,
-        // just verify that we hit the right endpoint
-        response.should.eql({mocked: true, branch: 'branch', project: 'project-alias'})
-        done()
-      })
-    })
-
-  })
-
-
-
-  describe("proxy", function(){
-    var nocker
-
-    before("nock out network calls", function(){
-      nocker = nockout('proxy_nocks.json', {
-        processor: function(nocks){
-          // persist first nock - it'll be called twice - for 'good build id' and 'server missing'
-          nocks[0] = nocks[0].persist()
-          return nocks
+    it('good project & pr', function(done) {
+      proxyLookup({pr: '2', project: 'project-alias'}, function(err, response) {
+        if (err) {
+          return done(err);
         }
-      })
+        // no need for the full proxy response here,
+        // just verify that we hit the right endpoint
+        response.should.eql({mocked: true, pr: '2', project: 'project-alias'});
+        done();
+      });
     });
 
-    after("cleanup", function(){
-      nocker.cleanup()
+    it('good project & branch', function(done) {
+      proxyLookup({branch: 'branch', project: 'project-alias'}, function(err, response) {
+        if (err) {
+          return done(err);
+        }
+
+        // No need for the full proxy response here, just verify that we hit
+        // the right endpoint
+        response.should.eql({mocked: true, branch: 'branch', project: 'project-alias'});
+        done();
+      });
+    });
+  });
+
+
+
+  describe('proxy', function() {
+    var nocker;
+
+    before('nock out network calls', function() {
+      nocker = nockout('proxy_nocks.json', {
+        processor: function(nocks) {
+          // persist first nock - it'll be called twice - for 'good build id' and 'server missing'
+          nocks[0] = nocks[0].persist();
+          return nocks;
+        },
+      });
     });
 
-    it("good build id", function* (){
-      var buildId = "ccb2f22d-6b31-49e3-b95b-98ec823bd6f8"
+    after('cleanup', function() {
+      nocker.cleanup();
+    });
+
+    it('good build id', function* () {
+      var buildId = 'ccb2f22d-6b31-49e3-b95b-98ec823bd6f8';
 
       try {
-        // makes 2 HTTP calls - one to lookup the proxy endpoint, and one to to the endpoint itself
+        // Makes 2 HTTP calls - one to lookup the proxy endpoint, and one to
+        // the endpoint itself.
         var result = yield request
             .get(`http://localhost:${server.address().port}`)
             .query({proboBuildId: buildId})
-            .end()
+            .end();
 
-        result.res.text.should.eql("proxied page")
-      } catch (e){
-        if(e.response){
-          console.log(e.response.error)
-        }
-        throw e
+        result.res.text.should.eql('proxied page');
       }
-    })
+      catch (e) {
+        if (e.response) {
+          console.log(e.response.error);
+        }
+        throw e;
+      }
+    });
 
-    // it("server missing", function* (){
-    //   var buildId = "ccb2f22d-6b31-49e3-b95b-98ec823bd6f8"
-
-    //   try {
-    //     // makes 2 HTTP calls
-    //     //  - one to lookup the proxy endpoint (first mock - 2nd time)
-    //     //  - one to the endpoint itself (mocked to 500 second time)
-    //     yield request
-    //         .get(`http://localhost:${server.address().port}`)
-    //         .query({proboBuildId: buildId})
-    //         .end()
-    //   } catch (e){
-    //     // console.log(e.response)
-
-    //     // confirm a 500 response (indicating lookup succeded, but proxied server isn't there)
-    //     e.response.status.should.eql(500)
-    //     e.response.text.should.eql(
-    //       'Proxy error: connect ECONNREFUSED 127.0.0.1:49348\n'
-    //     )
-    //     return
-    //   }
-    //   throw new Error("should not reach here")
-    // })
-
-    it("bad build id", function* (){
-      var buildId = "404"
+    it('bad build id', function* () {
+      var buildId = '404';
 
       try {
         yield request
             .get(`http://localhost:${server.address().port}`)
             .query({proboBuildId: buildId})
-            .end()
-      } catch (e){
+            .end();
+      }
+      catch (e) {
         // confirm a "Bad request" response (indicating lookup error)
-        e.response.status.should.eql(400)
+        e.response.status.should.eql(400);
         e.response.text.should.eql(
           'Proxy error: {"code":"ResourceNotFound","message":"Build not found for build id: 404"}\n'
-        )
+        );
       }
-    })
-  })
+    });
+  });
 
 
-  describe("proxy rewrites", function(){
-    function createProxyInfo(buildConfigSites, dest){
+  describe('proxy rewrites', function() {
+    function createProxyInfo(buildConfigSites, dest) {
       // sample options that will be passed in to the rewriter
       // (just including the probo part)
       var options = {
@@ -190,65 +176,77 @@ describe("lookup tests", function(){
           target: {
             url: 'http://localhost:49348/',
             dest: dest || {
-              id: 'ccb2f22d-6b31-49e3-b95b-98ec823bd6f8', post: undefined
+              id: 'ccb2f22d-6b31-49e3-b95b-98ec823bd6f8', post: undefined,
             },
             buildConfig: {
               image: 'lepew/ubuntu-14.04-lamp',
-              sites: buildConfigSites
-            }
-          }
-        }
-      }
+              sites: buildConfigSites,
+            },
+          },
+        },
+      };
 
       var proxyReq = http.request({
         // representative default headers
         headers: {
-          host: 'localhost:38937',
+          'host': 'localhost:38937',
           'accept-encoding': 'gzip, deflate',
           'user-agent': 'node-superagent/1.3.0',
-          connection: 'close',
+          'connection': 'close',
           'x-forwarded-for': '::ffff:127.0.0.1',
           'x-forwarded-port': '38937',
-          'x-forwarded-proto': 'http'
-        }
-      })
+          'x-forwarded-proto': 'http',
+        },
+      });
 
-      return {proxyReq, options}
+      return {proxyReq, options};
     }
 
-    it("nothing by default", function(done){
-      var proxyInfo = createProxyInfo()
-      proxy_rewrite(proxyInfo.proxyReq, null, null, proxyInfo.options)
+    it('nothing by default', function(done) {
+      var proxyInfo = createProxyInfo();
+      proxyRewrite(proxyInfo.proxyReq, null, null, proxyInfo.options);
 
-      "localhost:38937".should.eql(proxyInfo.proxyReq.getHeader('host'))
-      done()
-    })
+      'localhost:38937'.should.eql(proxyInfo.proxyReq.getHeader('host'));
+      done();
+    });
 
-    it("nothing by default but with sites specified", function(done){
-      var proxyInfo = createProxyInfo({us: 'us.domain.com'})
-      proxy_rewrite(proxyInfo.proxyReq, null, null, proxyInfo.options)
+    it('nothing by default but with sites specified', function(done) {
+      var proxyInfo = createProxyInfo({us: 'us.domain.com'});
+      proxyRewrite(proxyInfo.proxyReq, null, null, proxyInfo.options);
 
-      "localhost:38937".should.eql(proxyInfo.proxyReq.getHeader('host'))
-      done()
-    })
+      'localhost:38937'.should.eql(proxyInfo.proxyReq.getHeader('host'));
+      done();
+    });
 
-    it("default domain with bare build id", function(done){
-      var proxyInfo = createProxyInfo({ us: 'us.domain.com', default: 'domain.com' },
-                                      { id: "buildid" })
-      proxy_rewrite(proxyInfo.proxyReq, null, null, proxyInfo.options)
+    it('default domain with bare build id', function(done) {
+      var proxyInfo = createProxyInfo(
+        {
+          us: 'us.domain.com',
+          default: 'domain.com',
+        },
+        {id: 'buildid'}
+      );
+      proxyRewrite(proxyInfo.proxyReq, null, null, proxyInfo.options);
 
-      "domain.com".should.eql(proxyInfo.proxyReq.getHeader('host'))
-      done()
-    })
+      'domain.com'.should.eql(proxyInfo.proxyReq.getHeader('host'));
+      done();
+    });
 
-    it("specified domain with postfix syntax", function(done){
-      var proxyInfo = createProxyInfo({ us: 'us.domain.com', default: 'domain.com' },
-                                      { id: "buildid", site: "us" })
-      proxy_rewrite(proxyInfo.proxyReq, null, null, proxyInfo.options)
+    it('specified domain with postfix syntax', function(done) {
+      var proxyInfo = createProxyInfo(
+        {
+          us: 'us.domain.com',
+          default: 'domain.com',
+        },
+        {
+          id: 'buildid',
+          site: 'us',
+        }
+      );
+      proxyRewrite(proxyInfo.proxyReq, null, null, proxyInfo.options);
 
-      "us.domain.com".should.eql(proxyInfo.proxyReq.getHeader('host'))
-      done()
-    })
-  })
-
-})
+      'us.domain.com'.should.eql(proxyInfo.proxyReq.getHeader('host'));
+      done();
+    });
+  });
+});

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,161 +1,161 @@
-var utils = require('../lib/utils')
+'use strict';
 
-describe("utils", function(){
-  describe("getDest", function(){
-    it("gets dest from query param", function(){
-      var req = {
-        url: '/?proboDest=1234'
-      }
+var utils = require('../lib/utils');
 
-      var dest = utils.getDest(req)
-      dest.should.eql('1234')
-    })
+describe('utils', function() {
+  describe('getDest', function() {
+    it('gets dest from query param', function() {
+      var req = {url: '/?proboDest=1234'};
+      var dest = utils.getDest(req);
 
-    it("gets dest from proboBuildId query param (backwards compat)", function(){
-      var req = {
-        url: '/?proboBuildId=1234'
-      }
+      dest.should.eql('1234');
+    });
 
-      var dest = utils.getDest(req)
-      dest.should.eql('1234')
-    })
+    it('gets dest from proboBuildId query param (backwards compat)', function() {
+      var req = {url: '/?proboBuildId=1234'};
+      var dest = utils.getDest(req);
 
-    it("gets dest from HOST subdomain", function(){
+      dest.should.eql('1234');
+    });
+
+    it('gets dest from HOST subdomain', function() {
       var req = {
         url: '/',
         headers: {
-          host: '1234.domain.com'
-        }
-      }
-
-      var dest = utils.getDest(req)
-      dest.should.eql('1234')
-    })
-
-    it("errors when no dest is found", function(){
-      var req = {
-        url: '/',
-        headers: {
-          host: 'domain.com'
-        }
+          host: '1234.domain.com',
+        },
       };
 
-      (function(){
-        utils.getDest(req)
-      }).should.throw('Destination identifier not found in domain or query param, host: domain.com, url: /')
-    })
-  })
+      var dest = utils.getDest(req);
+      dest.should.eql('1234');
+    });
 
-  describe("parseDest", function(){
-    it("bare buildId", function(){
-      var dest = utils.parseDest("12345")
-      dest.build.should.eql("12345")
-    })
+    it('errors when no dest is found', function() {
+      var req = {
+        url: '/',
+        headers: {
+          host: 'domain.com',
+        },
+      };
 
-    it("buildId with site", function(){
-      var dest_str = "12-345--site-us"
-      var dest = utils.parseDest(dest_str)
+      (function() {
+        utils.getDest(req);
+      }).should.throw('Destination identifier not found in domain or query param, host: domain.com, url: /');
+    });
+  });
+
+  describe('parseDest', function() {
+    it('bare buildId', function() {
+      var dest = utils.parseDest('12345');
+      dest.build.should.eql('12345');
+    });
+
+    it('buildId with site', function() {
+      var destStr = '12-345--site-us';
+      var dest = utils.parseDest(destStr);
+
       dest.should.eql({
-        build: "12-345",
-        site: "us",
-        dest: dest_str
-      })
-    })
+        build: '12-345',
+        site: 'us',
+        dest: destStr,
+      });
+    });
 
-    it("modifier value can have dashes", function(){
-      var dest_str = "12-345--site-us-awesome-site"
-      var dest = utils.parseDest(dest_str)
-      dest.should.eql({
-        build: "12-345",
-        site: "us-awesome-site",
-        dest: dest_str
-      })
-    })
+    it('modifier value can have dashes', function() {
+      var destStr = '12-345--site-us-awesome-site';
+      var dest = utils.parseDest(destStr);
 
-    it("project id with PR", function(){
-      var dest_str = "12-345--pr-2"
-      var dest = utils.parseDest(dest_str)
       dest.should.eql({
-        project: "12-345",
-        pr: "2",
-        dest: dest_str
-      })
-    })
+        build: '12-345',
+        site: 'us-awesome-site',
+        dest: destStr,
+      });
+    });
 
-    it("project id with PR and site", function(){
-      var dest_str = "12-345--pr-2--site-us"
-      var dest = utils.parseDest(dest_str)
+    it('project id with PR', function() {
+      var destStr = '12-345--pr-2';
+      var dest = utils.parseDest(destStr);
+
       dest.should.eql({
-        project: "12-345",
-        site: "us",
+        project: '12-345',
         pr: '2',
-        dest: dest_str
-      })
-    })
+        dest: destStr,
+      });
+    });
 
-    it("project id with branch", function(){
-      var dest_str = "12-345--br-feature1"
-      var dest = utils.parseDest(dest_str)
-      dest.should.eql({
-        project: "12-345",
-        branch: "feature1",
-        dest: dest_str
-      })
-    })
+    it('project id with PR and site', function() {
+      var destStr = '12-345--pr-2--site-us';
+      var dest = utils.parseDest(destStr);
 
-    it("project id with branch and site", function(){
-      var dest_str = "12-345--br-feature2--site-us"
-      var dest = utils.parseDest(dest_str)
       dest.should.eql({
-        project: "12-345",
-        site: "us",
+        project: '12-345',
+        site: 'us',
+        pr: '2',
+        dest: destStr,
+      });
+    });
+
+    it('project id with branch', function() {
+      var destStr = '12-345--br-feature1';
+      var dest = utils.parseDest(destStr);
+      dest.should.eql({
+        project: '12-345',
+        branch: 'feature1',
+        dest: destStr,
+      });
+    });
+
+    it('project id with branch and site', function() {
+      var destStr = '12-345--br-feature2--site-us';
+      var dest = utils.parseDest(destStr);
+      dest.should.eql({
+        project: '12-345',
+        site: 'us',
         branch: 'feature2',
-        dest: dest_str
-      })
-    })
+        dest: destStr,
+      });
+    });
 
 
-    // test parse error conditions
+    // Test parse error conditions.
+    it('invalid modifier', function() {
+      var destStr = '12-345--blah';
 
-    it("invalid modifier", function(){
-      var dest_str = "12-345--blah";
+      (function() {
+        utils.parseDest(destStr);
+      }).should.throw('Destination identifier parse error: invalid modifier: blah');
+    });
 
-      (function(){
-        utils.parseDest(dest_str)
-      }).should.throw("Destination identifier parse error: invalid modifier: blah")
-    })
+    it('invalid modifier type', function() {
+      var destStr = '12-345--hello-world';
 
-    it("invalid modifier type", function(){
-      var dest_str = "12-345--hello-world";
+      (function() {
+        utils.parseDest(destStr);
+      }).should.throw('Destination identifier parse error: invalid modifier type: hello');
+    });
 
-      (function(){
-        utils.parseDest(dest_str)
-      }).should.throw("Destination identifier parse error: invalid modifier type: hello")
-    })
+    it('branch and pr should error', function() {
+      var destStr = '12-345--br-feature2--pr-34';
 
-    it("branch and pr should error", function(){
-      var dest_str = "12-345--br-feature2--pr-34";
+      (function() {
+        utils.parseDest(destStr);
+      }).should.throw('Destination identifier parse error: PR specified (34), but branch already set (feature2)');
+    });
 
-      (function(){
-        utils.parseDest(dest_str)
-      }).should.throw("Destination identifier parse error: PR specified (34), but branch already set (feature2)")
-    })
+    it('pr and branch should error', function() {
+      var destStr = '12-345--pr-34--br-feature2';
 
-    it("pr and branch should error", function(){
-      var dest_str = "12-345--pr-34--br-feature2";
+      (function() {
+        utils.parseDest(destStr);
+      }).should.throw('Destination identifier parse error: branch specified (feature2), but PR already set (34)');
+    });
 
-      (function(){
-        utils.parseDest(dest_str)
-      }).should.throw("Destination identifier parse error: branch specified (feature2), but PR already set (34)")
-    })
+    it('multiple site definitions should error', function() {
+      var destStr = '12-345--site-a--site-b';
 
-    it("multiple site definitions should error", function(){
-      var dest_str = "12-345--site-a--site-b";
-
-      (function(){
-        utils.parseDest(dest_str)
-      }).should.throw("Destination identifier parse error: multiple site definitions not allowed: b")
-    })
-
-  })
-})
+      (function() {
+        utils.parseDest(destStr);
+      }).should.throw('Destination identifier parse error: multiple site definitions not allowed: b');
+    });
+  });
+});


### PR DESCRIPTION
Related to:
https://github.com/ProboCI/probo-coordinator/pull/84
and
https://github.com/ProboCI/probo/pull/68
overlaps
https://github.com/ProboCI/probo-proxy/pull/4

\We want to have the proxy return better errors for humans in some cases.
Particularly, in the case of Probo SASS, we want the probo frontend to
be redirected to a nice error page. If however there is no front end and
the user is visiting the proxy URL via a browser, they should also see a
nice(r) error page. To handle this, configuration settings were added
that allow the proxy to be configured with a redirection URL for error
handling and a string of custom 404 error HTML. We inspect the request's
headers to determine if the response should be HTML (redirection or
HTML for a browser) or JSON (cli) or a plaintext response (no accept
headers sent).

### To test
 - `npm test` and ensure all tests pass.
 - Follow tests for https://github.com/ProboCI/probo/pull/68 to set up builds that are reaped or in progress.
 - Visit the proxy URLs for those builds via your browser
   - If you have a redirectionURL set you should be redirected
   - If you have no redirectionURL you should get an HTML response
 - Visit the proxy via curl with no special headers set, you should get a plaintext response
 - Visit the proxy via curl JSON accept headers set, you should get a JSON response
