### PR TITLE
Features/tizzo/improve error responses

### DIFF
--- a/defaults.yaml
+++ b/defaults.yaml
@@ -15,3 +15,7 @@ cacheMax: 500
 
 # Max age of proxy lookup responses in cache, in any unit (units default to ms). Defaults to 5 min
 cacheMaxAge: 1s
+
+redirectUrl: ''
+
+custom404Html: '<h1>404 - Build Not Found</h1><p>The build could not be found</p>'

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var ms = require('ms');
-
 var config = require('./lib/config');
 
 process.title = 'probo-proxy';

--- a/lib/config.js
+++ b/lib/config.js
@@ -36,6 +36,9 @@ if (argv.config) {
   if (typeof argv.config === 'string') {
     argv.config = [argv.config];
   }
+  for (let conf of argv.config) {
+    loader.add(path.resolve(conf));
+  }
 
   argv.config.forEach(function(val) {
     loader.add(path.resolve(val));

--- a/lib/config.js
+++ b/lib/config.js
@@ -2,7 +2,6 @@
 
 var path = require('path');
 var util = require('util');
-var _ = require('lodash');
 
 var Loader = require('yaml-config-loader');
 var yargs = require('yargs');
@@ -48,7 +47,7 @@ if (argv.config) {
 var setOptions = {};
 var key = null;
 for (key in yargs.argv) {
-  if (!_.isUndefined(yargs.argv[key])) {
+  if (yargs.argv.hasOwnProperty(key)) {
     setOptions[key] = yargs.argv[key];
   }
 }

--- a/lib/proxy-lookup.js
+++ b/lib/proxy-lookup.js
@@ -106,9 +106,13 @@ function lookup(dest, opts, cb) {
       return cb(new Error('Proxy lookup failed: ' + err.message));
     }
 
-    // TODO: should we cache error responses as well?
     if (response.statusCode !== 200) {
-      return cb(new Error(body));
+      var errorOptions = {
+        redirectUrl: config.redirectUrl,
+        custom404Html: config.custom404Html,
+      };
+      handleNonSuccessResponse(err, response, errorOptions, cb);
+      return;
     }
 
     try {
@@ -125,6 +129,31 @@ function lookup(dest, opts, cb) {
     }
     cb(null, body);
   });
+}
+
+function handleNonSuccessResponse(err, response, errorOptions, cb) {
+  var proxyError = new Error(response.body);
+  var proxyResponse = response.body;
+
+  try {
+    proxyResponse = JSON.parse(response.body);
+  }
+  catch (e) {
+    return cb(proxyError);
+  }
+
+  if (proxyResponse.errorCode) {
+    var proxyRedirect = errorOptions.redirectUrl ? errorOptions.redirectUrl + `?errorCode=${proxyResponse.errorCode}` : null;
+    var proxyHtml = errorOptions.custom404Html + `<p>${proxyResponse.message}</p>`;
+    proxyError = new Error();
+    proxyError.message = proxyResponse.message;
+    proxyError.statusCode = response.statusCode;
+    proxyError.errorCode = proxyResponse.errorCode;
+    proxyError.htmlResponse = proxyHtml;
+    proxyError.redirectUrl = proxyRedirect;
+  }
+
+  return cb(proxyError);
 }
 
 module.exports = lookup;

--- a/lib/proxy-lookup.js
+++ b/lib/proxy-lookup.js
@@ -143,7 +143,12 @@ function handleNonSuccessResponse(err, response, errorOptions, cb) {
   }
 
   if (proxyResponse.errorCode) {
-    var proxyRedirect = errorOptions.redirectUrl ? errorOptions.redirectUrl + `?errorCode=${proxyResponse.errorCode}` : null;
+    var proxyRedirect = null;
+    if (errorOptions.redirectUrl) {
+      proxyRedirect = errorOptions.redirectUrl + `?errorCode=${proxyResponse.errorCode}`;
+      proxyRedirect += `&reason=${proxyResponse.message}`;
+      proxyRedirect += `&buildId=${proxyResponse.buildId}`;
+    }
     var proxyHtml = errorOptions.custom404Html + `<p>${proxyResponse.message}</p>`;
     proxyError = new Error();
     proxyError.message = proxyResponse.message;

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -3,6 +3,7 @@
 var http = require('http');
 var httpProxy = require('http-proxy');
 var uuid = require('uuid');
+var _ = require('lodash');
 
 var utils = require('./utils');
 var proxyLookup = require('./proxy-lookup');
@@ -38,6 +39,10 @@ proxy.on('proxyRes', function(proxyRes, req, res) {
 
 function respondWithLookupError(req, res, err) {
   req.log.error({err}, 'Error looking up proxy information');
+  if (err.errorCode) {
+    respondWith404Message(req, res, err);
+  }
+
   res.writeHead(400);
   res.end(`Proxy error: ${err.message}\n`);
 }
@@ -48,7 +53,40 @@ function respondWithProxyError(req, res, err) {
   res.end(`Proxy error: ${err.message}\n`);
 }
 
+function respondWith404Message(req, res, err) {
+  // If the request was from a browser asking for HTML, then hand back a
+  // redirect to another page.
+  function accepts(s) {
+    return req.headers.accept && req.headers.accept.indexOf(s) >= 0;
+  }
+  var htmlAcceptStrings = ['text/html', 'application/xhtml', 'application/xml'];
+  var jsonAcceptStrings = ['application/json'];
 
+  if (_.includes(_.map(htmlAcceptStrings, accepts), true)) {
+    if (err.redirectUrl) {
+      res.writeHead(302, {
+        location: err.redirectUrl,
+      });
+    }
+    else {
+      res.writeHead(404, {
+        'Content-Type': 'text/html',
+      });
+      res.write(err.htmlResponse);
+    }
+  }
+  else if (_.includes(_.map(jsonAcceptStrings, accepts), true)) {
+    res.writeHead(404, {
+      'Content-Type': 'application/json',
+    });
+    res.write(JSON.stringify(err));
+  }
+  else {
+    res.writeHead(404);
+    res.write(`Proxy error: ${err.message}\n`);
+  }
+  res.end();
+}
 
 var server = http.createServer(function(req, res) {
   var dest;

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "bluebird": "^2.10.0",
     "co-mocha": "^1.1.2",
-    "eslint": "^1.10.3",
+    "eslint": "^2.10.2",
     "eslint-config-probo": "^1.0.2",
     "istanbul": "^0.3.19",
     "mocha": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -16,11 +16,11 @@
   "dependencies": {
     "bunyan": "^1.4.0",
     "http-proxy": "^1.11.1",
-    "lodash": "^3.10.1",
+    "lodash": "^4.12.0",
     "lru-cache": "^2.6.5",
     "ms": "^0.7.1",
     "request": "^2.60.0",
-    "restify": "^3.0.3",
+    "restify": "^4.0.4",
     "uuid": "^2.0.1",
     "yaml-config-loader": "^2.0.1",
     "yargs": "^4.6.0 "

--- a/test/fixtures/proxy_nocks.json
+++ b/test/fixtures/proxy_nocks.json
@@ -66,6 +66,86 @@
     }
   },
   {
+    "scope": "http://localhost:3020",
+    "method": "POST",
+    "path": "/container/proxy?build=aab2f22d-6b31-49e3-b95b-98ec823bd6f8&dest=aab2f22d-6b31-49e3-b95b-98ec823bd6f8",
+    "body": "",
+    "status": 404,
+    "response": {
+      "errorCode": "404R",
+      "message": "Build has been reaped"
+    },
+    "headers": {
+      "content-type": "application/json",
+      "date": "Wed, 09 Sep 2015 16:14:57 GMT",
+      "connection": "close"
+    }
+  },
+  {
+    "scope": "http://localhost:3020",
+    "method": "POST",
+    "path": "/container/proxy?build=acb2f22d-6b31-49e3-b95b-98ec823bd6f8&dest=acb2f22d-6b31-49e3-b95b-98ec823bd6f8",
+    "body": "",
+    "status": 404,
+    "response": {
+      "errorCode": "404R",
+      "message": "Build has been reaped"
+    },
+    "headers": {
+      "content-type": "application/json",
+      "date": "Wed, 09 Sep 2015 16:14:57 GMT",
+      "connection": "close"
+    }
+  },
+  {
+    "scope": "http://localhost:3020",
+    "method": "POST",
+    "path": "/container/proxy?build=adb2f22d-6b31-49e3-b95b-98ec823bd6f8&dest=adb2f22d-6b31-49e3-b95b-98ec823bd6f8",
+    "body": "",
+    "status": 404,
+    "response": {
+      "errorCode": "404R",
+      "message": "Build has been reaped"
+    },
+    "headers": {
+      "content-type": "application/json",
+      "date": "Wed, 09 Sep 2015 16:14:57 GMT",
+      "connection": "close"
+    }
+  },
+  {
+    "scope": "http://localhost:3020",
+    "method": "POST",
+    "path": "/container/proxy?build=eeb2f22d-6b31-49e3-b95b-98ec823bd6f8&dest=eeb2f22d-6b31-49e3-b95b-98ec823bd6f8",
+    "body": "",
+    "status": 404,
+    "response": {
+      "errorCode": "404R",
+      "message": "Build has been reaped"
+    },
+    "headers": {
+      "content-type": "application/json",
+      "date": "Wed, 09 Sep 2015 16:14:57 GMT",
+      "connection": "close"
+    }
+  },
+  {
+    "scope": "http://localhost:3020",
+    "method": "POST",
+    "path": "/container/proxy?build=efb2f22d-6b31-49e3-b95b-98ec823bd6f8&dest=efb2f22d-6b31-49e3-b95b-98ec823bd6f8",
+    "body": "",
+    "status": 404,
+    "response": {
+      "errorCode": "404R",
+      "message": "Build has been reaped"
+    },
+    "headers": {
+      "content-type": "application/json",
+      "date": "Wed, 09 Sep 2015 16:14:57 GMT",
+      "connection": "close"
+    }
+  },
+  {
     "scope": "http://localhost:49348/?proboBuildId=ccb2f22d-6b31-49e3-b95b-98ec823bd6f8",
     "method": "GET",
     "path": "/?proboBuildId=ccb2f22d-6b31-49e3-b95b-98ec823bd6f8",

--- a/test/server.js
+++ b/test/server.js
@@ -283,7 +283,7 @@ describe('lookup tests', function() {
           statusCode: 404,
           errorCode: '404R',
           htmlResponse: '<h1>THIS SHOULD BE A JSON RESPONSE</h1><p>Build has been reaped</p>',
-          redirectUrl: 'http://test.com?errorCode=404R'
+          redirectUrl: 'http://test.com?errorCode=404R',
         };
         e.response.statusCode.should.eql(404);
         e.response.text.should.eql(JSON.stringify(err));


### PR DESCRIPTION
Precludes #6 to include linting.

Related to:
ProboCI/probo-coordinator#84
and
ProboCI/probo#68
overlaps
#4

\We want to have the proxy return better errors for humans in some cases.
Particularly, in the case of Probo SASS, we want the probo frontend to
be redirected to a nice error page. If however there is no front end and
the user is visiting the proxy URL via a browser, they should also see a
nice(r) error page. To handle this, configuration settings were added
that allow the proxy to be configured with a redirection URL for error
handling and a string of custom 404 error HTML. We inspect the request's
headers to determine if the response should be HTML (redirection or
HTML for a browser) or JSON (cli) or a plaintext response (no accept
headers sent).

To test

npm test and ensure all tests pass.
Follow tests for ProboCI/probo#68 to set up builds that are reaped or in progress.
Visit the proxy URLs for those builds via your browser
If you have a redirectionURL set you should be redirected
If you have no redirectionURL you should get an HTML response
Visit the proxy via curl with no special headers set, you should get a plaintext response
Visit the proxy via curl JSON accept headers set, you should get a JSON response