### PR TITLE
Support HTTP Basic Access Authentication

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -117,8 +117,8 @@ var server = http.createServer(function(req, res) {
       let creds = result.proxy.basicAuth;
       if (creds.username && creds.password) {
         let user = auth(req);
-        if (!user || (user.name !== creds.username || user.pass !== creds.password)) {
-          res.writeHead(401, {'WWW-Authenticate': 'Basic realm="probo"'});
+        if (!user || (String(user.name) !== String(creds.username) || String(user.pass) !== String(creds.password))) {
+          res.writeHead(401, {'WWW-Authenticate': 'Basic realm="example"'});
           return res.end('Access denied');
         }
       }

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -2,6 +2,7 @@
 
 var http = require('http');
 var httpProxy = require('http-proxy');
+var auth = require('basic-auth');
 var uuid = require('uuid');
 var _ = require('lodash');
 
@@ -111,6 +112,17 @@ var server = http.createServer(function(req, res) {
       dest: dest,
       buildConfig: result.buildConfig,
     };
+
+    if (result.proxy.basicAuth) {
+      let creds = result.proxy.basicAuth;
+      if (creds.username && creds.password) {
+        let user = auth(req);
+        if (!user || (user.name !== creds.username || user.pass !== creds.password)) {
+          res.writeHead(401, {'WWW-Authenticate': 'Basic realm="probo"'});
+          return res.end('Access denied');
+        }
+      }
+    }
 
     _proxy(target, function(err, request, response, targetObj) {
       // callback only fires on error

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "author": "Ilya Braude <ilya@bluenexa.com>",
   "license": "Proprietary",
   "dependencies": {
+    "basic-auth": "^1.0.4",
     "bunyan": "^1.4.0",
     "http-proxy": "^1.11.1",
     "lodash": "^4.12.0",


### PR DESCRIPTION
Users have requested (#79) an easy way to add http basic auth to their builds. In the past we have coached them to set this up with apache .htaccess files but this makes the process a bit more seamless.

To test, add the following to your .probo.yaml file at the top level of the yaml file, run a build, and try to view it - you should be prompted for a username and password:

``` yaml
 basicAuth:
   username: foo
   password: bar
```

This is useless without ProboCI/probo#89 but can be deployed independently.
